### PR TITLE
Add high score tracking and scoreboard UI

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -166,6 +166,34 @@ body {
 .panel button:hover {
   background: #4350b3;
 }
+
+#player-name {
+  padding: 8px 12px;
+  font-size: 18px;
+  border-radius: 8px;
+  border: 2px solid #5563de;
+  margin-bottom: 15px;
+  width: 100%;
+}
+
+#scores-btn {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: #ffce00;
+  border: none;
+  font-size: 28px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  z-index: 11;
+}
+
+#scores-btn:hover {
+  background: #e0b700;
+}
 /* Confetti */
 #confetti-container {
   position: fixed;

--- a/index.html
+++ b/index.html
@@ -35,9 +35,26 @@
       <div class="panel">
         <h1>Game Over</h1>
         <p>You’ve run out of moves.</p>
-        <button onclick="restartGame()">Restart</button>
+        <input
+          id="player-name"
+          type="text"
+          placeholder="Enter your name"
+          onkeydown="if(event.key==='Enter')submitScore()"
+        />
+        <button onclick="submitScore()">Submit</button>
       </div>
     </div>
+
+    <!-- High Scores Overlay -->
+    <div id="scores-overlay" class="overlay">
+      <div class="panel">
+        <h1>High Scores</h1>
+        <ol id="scores-list"></ol>
+        <button onclick="closeScores()">Close</button>
+      </div>
+    </div>
+
+    <button id="scores-btn" onclick="showScores()">🏆</button>
 
     <!-- Confetti Container -->
     <div id="confetti-container"></div>

--- a/js/app.js
+++ b/js/app.js
@@ -9,6 +9,7 @@ let selectedTile = null,
   gameOver = false,
   hintTimeout;
 let cascadeCount = 1;
+const HIGH_SCORES_KEY = "vibey_high_scores";
 
 function getThreshold(lv) {
   const raw = 15 * (lv / 2);
@@ -72,6 +73,7 @@ function renderBoard() {
     gameOver = true;
     clearTimeout(hintTimeout);
     document.getElementById("gameover-overlay").classList.add("visible");
+    document.getElementById("player-name").focus();
   }
 }
 
@@ -331,6 +333,48 @@ function showHint() {
         el.classList.add("hint");
     });
   }, 50);
+}
+
+function loadHighScores() {
+  try {
+    return JSON.parse(localStorage.getItem(HIGH_SCORES_KEY)) || [];
+  } catch {
+    return [];
+  }
+}
+
+function saveHighScores(scores) {
+  localStorage.setItem(HIGH_SCORES_KEY, JSON.stringify(scores));
+}
+
+function addHighScore(name, score) {
+  const scores = loadHighScores();
+  scores.push({ name, score });
+  scores.sort((a, b) => b.score - a.score);
+  if (scores.length > 10) scores.length = 10;
+  saveHighScores(scores);
+}
+
+function submitScore() {
+  const input = document.getElementById("player-name");
+  const name = input.value.trim() || "Anonymous";
+  addHighScore(name, Math.floor(totalScore));
+  input.value = "";
+  restartGame();
+}
+
+function showScores() {
+  const overlay = document.getElementById("scores-overlay");
+  const list = document.getElementById("scores-list");
+  const scores = loadHighScores();
+  list.innerHTML = scores
+    .map((s) => `<li>${s.name}: ${s.score}</li>`)
+    .join("");
+  overlay.classList.add("visible");
+}
+
+function closeScores() {
+  document.getElementById("scores-overlay").classList.remove("visible");
 }
 
 function startGame() {


### PR DESCRIPTION
## Summary
- record high scores in LocalStorage
- ask for a player name on game over
- show a floating button to view a high score list in a modal
- style the input field and score button

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843b5877a40832f8528421a02a52d99