### PR TITLE
Fix row/column clear for five-match

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -167,7 +167,7 @@ function processMatches() {
       ) {
         run++;
       } else if (run >= 5) {
-        clearMany(Array.from({ length: run }, (_, i) => [r, c - run + i]));
+        clearMany(Array.from({ length: boardCols }, (_, i) => [r, i]));
         return;
       } else {
         run = 1;
@@ -185,7 +185,7 @@ function processMatches() {
       ) {
         run++;
       } else if (run >= 5) {
-        clearMany(Array.from({ length: run }, (_, i) => [r - run + i, c]));
+        clearMany(Array.from({ length: boardRows }, (_, i) => [i, c]));
         return;
       } else {
         run = 1;


### PR DESCRIPTION
## Summary
- clear the entire row or column when matching 5 or more tiles

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843b5b017f4832f8801d8f611651b0f