### PR TITLE
Add Tone.js audio feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Vibe-coded to test AI capabilities.
 - **Tutorial & Game Over Overlays**: First-play guidance and custom end screen with restart.
 - **Smooth Animations**: Tile swaps, falls, shakes, fades, and confetti.
 - **High Scores**: Submit your name after game over and view the top scores via the trophy button.
+- **Random Tones**: Each match plays a random note using Tone.js.
 
 ## Getting Started
 

--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@
     <!-- Confetti Container -->
     <div id="confetti-container"></div>
 
+    <script src="https://cdn.jsdelivr.net/npm/tone@14.7.77/build/Tone.min.js"></script>
     <script src="js/app.js"></script>
   </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -11,6 +11,19 @@ let selectedTile = null,
 let cascadeCount = 1;
 const HIGH_SCORES_KEY = "vibey_high_scores";
 
+// Tone.js setup
+let synth = null;
+const notes = ["C4", "D4", "E4", "G4", "A4", "B4", "C5"];
+if (typeof Tone !== "undefined") {
+  synth = new Tone.Synth().toDestination();
+}
+
+function playRandomTone() {
+  if (!synth) return;
+  const note = notes[Math.floor(Math.random() * notes.length)];
+  synth.triggerAttackRelease(note, "8n");
+}
+
 function getThreshold(lv) {
   const raw = 15 * (lv / 2);
   return Math.ceil(raw / 5) * 5;
@@ -247,6 +260,7 @@ function processMatches() {
 }
 
 function clearMany(cells) {
+  playRandomTone();
   const base = cells.length;
   const bonus = (cascadeCount - 1) * 0.5;
   totalScore += base + bonus;
@@ -379,6 +393,7 @@ function closeScores() {
 
 function startGame() {
   document.getElementById("tutorial-overlay").classList.remove("visible");
+  if (typeof Tone !== "undefined") Tone.start();
   restartGame();
 }
 function restartGame() {


### PR DESCRIPTION
## Summary
- play random notes on each match using Tone.js
- load Tone.js from CDN in `index.html`
- mention audio feedback in README

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6843b7b559c4832fa9146a68cbc2cbc9