### PR TITLE
Add sound toggle button

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -194,6 +194,25 @@ body {
 #scores-btn:hover {
   background: #e0b700;
 }
+
+#sound-toggle {
+  position: fixed;
+  bottom: 20px;
+  right: 90px;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: #ffce00;
+  border: none;
+  font-size: 28px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  z-index: 11;
+}
+
+#sound-toggle:hover {
+  background: #e0b700;
+}
 /* Confetti */
 #confetti-container {
   position: fixed;

--- a/index.html
+++ b/index.html
@@ -55,6 +55,7 @@
     </div>
 
     <button id="scores-btn" onclick="showScores()">🏆</button>
+    <button id="sound-toggle">🔊</button>
 
     <!-- Confetti Container -->
     <div id="confetti-container"></div>

--- a/js/app.js
+++ b/js/app.js
@@ -10,6 +10,12 @@ let selectedTile = null,
   hintTimeout;
 let cascadeCount = 1;
 const HIGH_SCORES_KEY = "vibey_high_scores";
+const SOUND_ENABLED_KEY = "vibey_sound_enabled";
+let soundEnabled = true;
+try {
+  const saved = localStorage.getItem(SOUND_ENABLED_KEY);
+  if (saved !== null) soundEnabled = saved === "true";
+} catch {}
 
 // Tone.js setup
 let synth = null;
@@ -19,7 +25,7 @@ if (typeof Tone !== "undefined") {
 }
 
 function playRandomTone() {
-  if (!synth) return;
+  if (!synth || !soundEnabled) return;
   const note = notes[Math.floor(Math.random() * notes.length)];
   synth.triggerAttackRelease(note, "8n");
 }
@@ -391,6 +397,19 @@ function closeScores() {
   document.getElementById("scores-overlay").classList.remove("visible");
 }
 
+function updateSoundToggle() {
+  const btn = document.getElementById("sound-toggle");
+  if (btn) btn.textContent = soundEnabled ? "🔊" : "🔇";
+}
+
+function toggleSound() {
+  soundEnabled = !soundEnabled;
+  updateSoundToggle();
+  try {
+    localStorage.setItem(SOUND_ENABLED_KEY, soundEnabled);
+  } catch {}
+}
+
 function startGame() {
   document.getElementById("tutorial-overlay").classList.remove("visible");
   if (typeof Tone !== "undefined") Tone.start();
@@ -416,3 +435,7 @@ board = generateBoard();
 renderBoard();
 resetHintTimer();
 setTimeout(processMatches, 300);
+
+updateSoundToggle();
+document.getElementById("sound-toggle").onclick = toggleSound;
+


### PR DESCRIPTION
## Summary
- add sound toggle button near the trophy button
- style sound button like the trophy button
- save sound preference and toggle sound playback in JS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843ba3e4800832faced66b6f2465877