### PR TITLE
Add background transitions for level ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Vibe-coded to test AI capabilities.
   - Match 4 to clear an entire row or column.
   - Match 5 or more to clear all tiles in that row or column.
 - **Level Progression**: Reach a threshold to level up, unlocking extra rows/columns and a confetti celebration.
+- **Colourful Level Transitions**: Each new level smoothly changes the page background colour.
 - **Hint System**: After 10 seconds of inactivity, tiles fade to gold indicating a possible move.
 - **Tutorial & Game Over Overlays**: First-play guidance and custom end screen with restart.
 - **Smooth Animations**: Tile swaps, falls, shakes, fades, and confetti.

--- a/css/styles.css
+++ b/css/styles.css
@@ -7,6 +7,7 @@
 body {
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   background: linear-gradient(135deg, #74abe2 0%, #5563de 100%);
+  transition: background 0.5s ease;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/js/app.js
+++ b/js/app.js
@@ -38,6 +38,12 @@ function getRandomTile() {
   return tileTypes[Math.floor(Math.random() * tileTypes.length)];
 }
 
+function updateBackground() {
+  const hue = (level * 40) % 360;
+  const nextHue = (hue + 60) % 360;
+  document.body.style.background = `linear-gradient(135deg, hsl(${hue},70%,70%), hsl(${nextHue},70%,60%))`;
+}
+
 function updateUI() {
   document.getElementById("level").textContent = `Level: ${level}`;
   document.getElementById("score").textContent = `Score: ${Math.floor(
@@ -280,6 +286,7 @@ function clearMany(cells) {
     if (level % 5 === 0) boardCols = Math.min(boardCols + 1, 20);
     if (level % 10 === 0) boardRows = Math.min(boardRows + 1, 15);
     launchConfetti();
+    updateBackground();
     threshold = getThreshold(level);
   }
 
@@ -427,6 +434,7 @@ function restartGame() {
   boardCols = 5;
   gameOver = false;
   cascadeCount = 1;
+  updateBackground();
   board = generateBoard();
   renderBoard();
   resetHintTimer();
@@ -438,6 +446,7 @@ board = generateBoard();
 renderBoard();
 resetHintTimer();
 setTimeout(processMatches, 300);
+updateBackground();
 
 updateSoundToggle();
 document.getElementById("sound-toggle").onclick = toggleSound;


### PR DESCRIPTION
## Summary
- animate body background on level changes
- update game logic to set new gradient for each level
- mention the feature in the README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843bcdf49b4832f974f33bd76d23870