### PR TITLE
Implement Shuffle continuation feature

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -262,3 +262,7 @@ body {
   background: #ffce00;
   transition: width 0.3s ease;
 }
+
+#shuffle-option {
+  margin-bottom: 15px;
+}

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
       <div id="level">Level: 1</div>
       <div id="score">Score: 0</div>
       <div id="remaining">Next in: 10</div>
+      <div id="shuffles">Shuffles: 0</div>
     </div>
     <div id="progress"><div class="bar"></div></div>
     <div id="game"></div>
@@ -36,6 +37,10 @@
       <div class="panel">
         <h1>Game Over</h1>
         <p>You’ve run out of moves.</p>
+        <div id="shuffle-option" style="display: none">
+          <p id="shuffle-count-text"></p>
+          <button onclick="useShuffle()">Use Shuffle</button>
+        </div>
         <input
           id="player-name"
           type="text"


### PR DESCRIPTION
## Summary
- award shuffles every 100 points and show count in UI
- let players use a shuffle on game over
- play a short jingle when a shuffle is earned

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684439f33a08832f946daba8773c64f3