### PR TITLE
Show high scores after losing

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -155,6 +155,19 @@ body {
   margin-bottom: 10px;
   color: #333;
 }
+.scores-list {
+  list-style: none;
+  padding: 0;
+  margin: 10px 0 20px;
+  text-align: left;
+}
+.scores-list li {
+  background: #f5f5f5;
+  padding: 6px 12px;
+  border-radius: 8px;
+  margin-bottom: 6px;
+  font-size: 18px;
+}
 .panel p {
   margin-bottom: 20px;
   font-size: 18px;

--- a/index.html
+++ b/index.html
@@ -43,6 +43,9 @@
           onkeydown="if(event.key==='Enter')submitScore()"
         />
         <button onclick="submitScore()">Submit</button>
+        <h2>High Scores</h2>
+        <p class="scores-note">Each entry shows the level reached.</p>
+        <ol id="scores-list-gameover" class="scores-list"></ol>
       </div>
     </div>
 
@@ -51,7 +54,7 @@
       <div class="panel">
         <h1>High Scores</h1>
         <p class="scores-note">Each entry shows the level reached.</p>
-        <ol id="scores-list"></ol>
+        <ol id="scores-list" class="scores-list"></ol>
         <button onclick="closeScores()">Close</button>
       </div>
     </div>

--- a/js/app.js
+++ b/js/app.js
@@ -119,6 +119,7 @@ function renderBoard() {
   if (!gameOver && !findHint()) {
     gameOver = true;
     clearTimeout(hintTimeout);
+    populateScores(document.getElementById("scores-list-gameover"));
     document.getElementById("gameover-overlay").classList.add("visible");
     document.getElementById("player-name").focus();
   }
@@ -404,24 +405,29 @@ function addHighScore(name, score, reachedLevel) {
   saveHighScores(scores);
 }
 
+function populateScores(listEl) {
+  const scores = loadHighScores();
+  listEl.innerHTML = scores
+    .map((s) => {
+      const lvl = s.level !== undefined ? s.level : "?";
+      return `<li>${s.name}: ${s.score} (Level ${lvl})</li>`;
+    })
+    .join("");
+}
+
 function submitScore() {
   const input = document.getElementById("player-name");
   const name = input.value.trim() || "Anonymous";
   addHighScore(name, Math.floor(totalScore), level);
   input.value = "";
   restartGame();
+  showScores();
 }
 
 function showScores() {
   const overlay = document.getElementById("scores-overlay");
   const list = document.getElementById("scores-list");
-  const scores = loadHighScores();
-  list.innerHTML = scores
-    .map((s) => {
-      const lvl = s.level !== undefined ? s.level : "?";
-      return `<li>${s.name}: ${s.score} (Level ${lvl})</li>`;
-    })
-    .join("");
+  populateScores(list);
   overlay.classList.add("visible");
 }
 


### PR DESCRIPTION
## Summary
- embed high score table in the Game Over overlay
- style the high score list for clarity
- populate scores whenever the game ends and display the list after submitting a score

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68443a10385c832fbe9dd264d34b7f41