### PR TITLE
Add shuffle continue mechanic

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Vibe-coded to test AI capabilities.
 - **Smooth Animations**: Tile swaps, falls, shakes, fades, and confetti.
 - **High Scores**: Submit your name after game over to save your score and the level reached. View the top results via the trophy button.
 - **Random Tones**: Each match plays a random note using Tone.js.
+- **Shuffles**: Earn a shuffle every 100 points to continue when no moves remain.
 
 ## Getting Started
 
@@ -31,3 +32,4 @@ Vibe-coded to test AI capabilities.
 - **Cascades**: Trigger chain reactions for bonus points.
 - **Level Up**: Earn enough points to advance levels and expand the board.
 - **No Moves Left**: Game ends when no valid match is possible.
+- **Use Shuffles**: If you have a shuffle available on game over, you can shuffle the board and keep playing.

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
       <div id="level">Level: 1</div>
       <div id="score">Score: 0</div>
       <div id="remaining">Next in: 10</div>
+      <div id="shuffles">Shuffles: 0</div>
     </div>
     <div id="progress"><div class="bar"></div></div>
     <div id="game"></div>


### PR DESCRIPTION
## Summary
- award a Shuffle every 100 points and display remaining shuffles
- let players spend a Shuffle when out of moves
- play a short Tone.js jingle when a shuffle is earned
- document the new feature

## Testing
- `node --check js/app.js`

------
https://chatgpt.com/codex/tasks/task_e_684443560f18832fb534750371429d68