### PR TITLE
Add shuffle continue mechanic

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Vibe-coded to test AI capabilities.
 - **Smooth Animations**: Tile swaps, falls, shakes, fades, and confetti.
 - **High Scores**: Submit your name after game over to save your score and the level reached. View the top results via the trophy button.
 - **Random Tones**: Each match plays a random note using Tone.js.
+- **Shuffles**: Earn a shuffle every 100 points to continue when no moves remain.
 
 ## Getting Started
 
@@ -31,3 +32,4 @@ Vibe-coded to test AI capabilities.
 - **Cascades**: Trigger chain reactions for bonus points.
 - **Level Up**: Earn enough points to advance levels and expand the board.
 - **No Moves Left**: Game ends when no valid match is possible.
+- **Use Shuffles**: If you have a shuffle available on game over, you can shuffle the board and keep playing.

--- a/css/styles.css
+++ b/css/styles.css
@@ -173,6 +173,12 @@ body {
   font-size: 18px;
   line-height: 1.4;
 }
+.button-row {
+  display: flex;
+  gap: 20px;
+  justify-content: center;
+  margin-top: 10px;
+}
 .panel button {
   font-size: 18px;
   padding: 10px 20px;

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
       <div id="level">Level: 1</div>
       <div id="score">Score: 0</div>
       <div id="remaining">Next in: 10</div>
+      <div id="shuffles">Shuffles: 0</div>
     </div>
     <div id="progress"><div class="bar"></div></div>
     <div id="game"></div>
@@ -46,6 +47,18 @@
         <h2>High Scores</h2>
         <p class="scores-note">Each entry shows the level reached.</p>
         <ol id="scores-list-gameover" class="scores-list"></ol>
+      </div>
+    </div>
+
+    <!-- Continue Overlay -->
+    <div id="continue-overlay" class="overlay">
+      <div class="panel">
+        <h1>No Moves Left</h1>
+        <p>Use a shuffle to continue?</p>
+        <div class="button-row">
+          <button id="use-shuffle">Use Shuffle</button>
+          <button id="end-game">End Game</button>
+        </div>
       </div>
     </div>
 

--- a/js/app.js
+++ b/js/app.js
@@ -10,6 +10,8 @@ let selectedTile = null,
   hintTimeout;
 let dragStart = null;
 let cascadeCount = 1;
+let shuffles = 0;
+let shufflesEarned = 0;
 const HIGH_SCORES_KEY = "vibey_high_scores";
 const SOUND_ENABLED_KEY = "vibey_sound_enabled";
 let soundEnabled = true;
@@ -29,6 +31,23 @@ function playRandomTone() {
   if (!synth || !soundEnabled) return;
   const note = notes[Math.floor(Math.random() * notes.length)];
   synth.triggerAttackRelease(note, "8n");
+}
+
+function playJingle() {
+  if (!synth || !soundEnabled) return;
+  synth.triggerAttackRelease("C5", "8n");
+  setTimeout(() => synth.triggerAttackRelease("E5", "8n"), 150);
+  setTimeout(() => synth.triggerAttackRelease("G5", "8n"), 300);
+}
+
+function checkShuffleAward() {
+  const earned = Math.floor(totalScore / 100);
+  if (earned > shufflesEarned) {
+    shuffles += earned - shufflesEarned;
+    shufflesEarned = earned;
+    playJingle();
+    updateUI();
+  }
 }
 
 function getThreshold(lv) {
@@ -58,6 +77,8 @@ function updateUI() {
   const percent = Math.min(100, (levelScore / threshold) * 100);
   const bar = document.querySelector("#progress .bar");
   if (bar) bar.style.width = `${percent}%`;
+  const shufEl = document.getElementById("shuffles");
+  if (shufEl) shufEl.textContent = `Shuffles: ${shuffles}`;
 }
 
 function generateBoard() {
@@ -117,11 +138,11 @@ function renderBoard() {
   }
   updateUI();
   if (!gameOver && !findHint()) {
-    gameOver = true;
-    clearTimeout(hintTimeout);
-    populateScores(document.getElementById("scores-list-gameover"));
-    document.getElementById("gameover-overlay").classList.add("visible");
-    document.getElementById("player-name").focus();
+    if (shuffles > 0) {
+      showContinueOverlay();
+      return;
+    }
+    triggerGameOver();
   }
 }
 
@@ -301,6 +322,7 @@ function clearMany(cells) {
   totalScore += base + bonus;
   levelScore += base + bonus;
   cascadeCount++;
+  checkShuffleAward();
 
   let threshold = getThreshold(level);
   while (levelScore >= threshold) {
@@ -354,6 +376,17 @@ function refillBoard() {
     });
   });
   resetHintTimer();
+}
+
+function shuffleBoard() {
+  let attempts = 0;
+  do {
+    board = generateBoard();
+    attempts++;
+  } while (!findHint() && attempts < 10);
+  renderBoard();
+  resetHintTimer();
+  setTimeout(processMatches, 300);
 }
 
 function launchConfetti() {
@@ -435,6 +468,34 @@ function closeScores() {
   document.getElementById("scores-overlay").classList.remove("visible");
 }
 
+function showContinueOverlay() {
+  document.getElementById("continue-overlay").classList.add("visible");
+}
+
+function hideContinueOverlay() {
+  document.getElementById("continue-overlay").classList.remove("visible");
+}
+
+function useShuffle() {
+  if (shuffles <= 0) return;
+  shuffles--;
+  hideContinueOverlay();
+  shuffleBoard();
+}
+
+function triggerGameOver() {
+  gameOver = true;
+  clearTimeout(hintTimeout);
+  populateScores(document.getElementById("scores-list-gameover"));
+  document.getElementById("gameover-overlay").classList.add("visible");
+  document.getElementById("player-name").focus();
+}
+
+function endGame() {
+  hideContinueOverlay();
+  triggerGameOver();
+}
+
 function updateSoundToggle() {
   const btn = document.getElementById("sound-toggle");
   if (btn) btn.textContent = soundEnabled ? "🔊" : "🔇";
@@ -462,6 +523,8 @@ function restartGame() {
   boardCols = 5;
   gameOver = false;
   cascadeCount = 1;
+  shuffles = 0;
+  shufflesEarned = 0;
   updateBackground();
   board = generateBoard();
   renderBoard();
@@ -478,4 +541,6 @@ updateBackground();
 
 updateSoundToggle();
 document.getElementById("sound-toggle").onclick = toggleSound;
+document.getElementById("use-shuffle").onclick = useShuffle;
+document.getElementById("end-game").onclick = endGame;
 


### PR DESCRIPTION
## Summary
- award a Shuffle every 100 points and display remaining shuffles
- let players spend a Shuffle when out of moves
- play a short Tone.js jingle when a shuffle is earned
- replace the browser confirm dialog with a CSS modal
- document the new feature

## Testing
- `node --check js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_684443560f18832fb534750371429d68