### PR TITLE
Update board clear when matching 5+ tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Vibe-coded to test AI capabilities.
 - **Cascade Bonuses**: Earn 0.5 bonus points per consecutive cascade.
 - **Special Clears**:
   - Match 4 to clear an entire row or column.
-  - Match 5 or more to clear all tiles in that row or column.
+  - Match 5 or more to clear every tile on the board.
 - **Level Progression**: Reach a threshold to level up, unlocking extra rows/columns and a confetti celebration.
 - **Colourful Level Transitions**: Each new level smoothly changes the page background colour.
 - **Hint System**: After 10 seconds of inactivity, tiles fade to gold indicating a possible move.

--- a/js/app.js
+++ b/js/app.js
@@ -248,7 +248,11 @@ function processMatches() {
       ) {
         run++;
       } else if (run >= 5) {
-        clearMany(Array.from({ length: boardCols }, (_, i) => [r, i]));
+        clearMany(
+          Array.from({ length: boardRows }, (_, rr) =>
+            Array.from({ length: boardCols }, (_, cc) => [rr, cc])
+          ).flat()
+        );
         return;
       } else {
         run = 1;
@@ -266,7 +270,11 @@ function processMatches() {
       ) {
         run++;
       } else if (run >= 5) {
-        clearMany(Array.from({ length: boardRows }, (_, i) => [i, c]));
+        clearMany(
+          Array.from({ length: boardRows }, (_, rr) =>
+            Array.from({ length: boardCols }, (_, cc) => [rr, cc])
+          ).flat()
+        );
         return;
       } else {
         run = 1;


### PR DESCRIPTION
## Summary
- update special clear behavior to wipe the board when matching 5 or more tiles
- document the updated rule in the README

## Testing
- `node --check js/app.js`

------
https://chatgpt.com/codex/tasks/task_e_684446868188832fa3995a1a305d72b9