### PR TITLE
Fix scoreboard DOM injection risk

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -448,12 +448,13 @@ function addHighScore(name, score, reachedLevel) {
 
 function populateScores(listEl) {
   const scores = loadHighScores();
-  listEl.innerHTML = scores
-    .map((s) => {
-      const lvl = s.level !== undefined ? s.level : "?";
-      return `<li>${s.name}: ${s.score} (Level ${lvl})</li>`;
-    })
-    .join("");
+  listEl.innerHTML = "";
+  scores.forEach((s) => {
+    const lvl = s.level !== undefined ? s.level : "?";
+    const li = document.createElement("li");
+    li.textContent = `${s.name}: ${s.score} (Level ${lvl})`;
+    listEl.appendChild(li);
+  });
 }
 
 function submitScore() {


### PR DESCRIPTION
## Summary
- avoid setting HTML using strings when populating high scores

## Testing
- `npx eslint .` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68444d1bcbd0832f9b3546dfe90a1ff4