### PR TITLE
Fix tiles staying invisible after match

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -49,6 +49,9 @@ function renderBoard() {
   }
 
   const cells = g.children;
+  for (let i = 0; i < cells.length; i++) {
+    cells[i].classList.remove('fading', 'falling', 'hint', 'shake');
+  }
   for (let r = 0; r < game.boardRows; r++) {
     for (let c = 0; c < game.boardCols; c++) {
       const cell = cells[r * game.boardCols + c];


### PR DESCRIPTION
## Summary
- clear fading, falling, hint and shake classes when re-rendering board

## Testing
- `node test/findRuns.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68445ee67674832f93897862873f4e6c