### PR TITLE
Delay Tone synth init until user interaction

### DIFF
--- a/js/audio.js
+++ b/js/audio.js
@@ -7,9 +7,13 @@ try {
 
 // Tone.js setup
 let synth = null;
+let audioReady = false;
 const notes = ["C4", "D4", "E4", "G4", "A4", "B4", "C5"];
-if (typeof Tone !== "undefined") {
+
+export function initAudio() {
+  if (typeof Tone === "undefined") return;
   synth = new Tone.Synth().toDestination();
+  audioReady = true;
 }
 
 export function isSoundEnabled() {
@@ -25,13 +29,13 @@ export function toggleSoundEnabled() {
 }
 
 export function playRandomTone() {
-  if (!synth || !soundEnabled) return;
+  if (!audioReady || !soundEnabled) return;
   const note = notes[Math.floor(Math.random() * notes.length)];
   synth.triggerAttackRelease(note, "8n");
 }
 
 export function playJingle() {
-  if (!synth || !soundEnabled) return;
+  if (!audioReady || !soundEnabled) return;
   synth.triggerAttackRelease("C5", "8n");
   setTimeout(() => synth.triggerAttackRelease("E5", "8n"), 150);
   setTimeout(() => synth.triggerAttackRelease("G5", "8n"), 300);

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,5 +1,5 @@
 import { Game } from './game.js';
-import { toggleSoundEnabled, isSoundEnabled } from './audio.js';
+import { toggleSoundEnabled, isSoundEnabled, initAudio } from './audio.js';
 import {
   loadHighScores,
   addHighScore,
@@ -195,9 +195,12 @@ function hideShufflePrompt() {
   document.getElementById('shuffle-overlay').classList.remove('visible');
 }
 
-export function startGame() {
+export async function startGame() {
   document.getElementById('tutorial-overlay').classList.remove('visible');
-  if (typeof Tone !== 'undefined') Tone.start();
+  if (typeof Tone !== 'undefined') {
+    await Tone.start();
+  }
+  initAudio();
   restartGame();
 }
 


### PR DESCRIPTION
## Summary
- move synth setup into `initAudio()` for explicit initialization
- skip tone playback if audio isn't ready
- await `Tone.start()` before starting the game

## Testing
- `node test/findRuns.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_684466b92de0832fb6df5f0bafc6c301