### PR TITLE
Graceful handling of high score storage errors

### DIFF
--- a/js/scores.js
+++ b/js/scores.js
@@ -10,7 +10,9 @@ export function loadHighScores() {
 }
 
 export function saveHighScores(scores) {
-  localStorage.setItem(HIGH_SCORES_KEY, JSON.stringify(scores));
+  try {
+    localStorage.setItem(HIGH_SCORES_KEY, JSON.stringify(scores));
+  } catch {}
 }
 
 export function addHighScore(name, score, reachedLevel) {


### PR DESCRIPTION
## Summary
- wrap high score persistence in a try/catch

## Testing
- `node test/findRuns.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_684466bcd030832f88202180ba6d378b