### PR TITLE
Fix shuffle award audio

### DIFF
--- a/js/audio.js
+++ b/js/audio.js
@@ -6,14 +6,16 @@ try {
 } catch {}
 
 // Tone.js setup
-let synth = null;
+let noteSynth = null;
+let jingleSynth = null;
 let audioReady = false;
 const notes = ["C4", "D4", "E4", "G4", "A4", "B4", "C5"];
 let lastScheduled = 0;
 
 export function initAudio() {
   if (typeof Tone === "undefined") return;
-  synth = new Tone.Synth().toDestination();
+  noteSynth = new Tone.Synth().toDestination();
+  jingleSynth = new Tone.Synth().toDestination();
   audioReady = true;
 }
 
@@ -32,15 +34,15 @@ export function toggleSoundEnabled() {
 export function playRandomTone() {
   if (!audioReady || !soundEnabled) return;
   const note = notes[Math.floor(Math.random() * notes.length)];
-  synth.triggerAttackRelease(note, "8n");
+  noteSynth.triggerAttackRelease(note, "8n");
 }
 
 export function playJingle() {
   if (!audioReady || !soundEnabled) return;
   const now = Tone.now();
   const start = Math.max(now, lastScheduled + 0.01);
-  synth.triggerAttackRelease("C5", "8n", start);
-  synth.triggerAttackRelease("E5", "8n", start + 0.15);
-  synth.triggerAttackRelease("G5", "8n", start + 0.3);
+  jingleSynth.triggerAttackRelease("C5", "8n", start);
+  jingleSynth.triggerAttackRelease("E5", "8n", start + 0.15);
+  jingleSynth.triggerAttackRelease("G5", "8n", start + 0.3);
   lastScheduled = start + 0.3;
 }

--- a/js/game.js
+++ b/js/game.js
@@ -232,13 +232,13 @@ export class Game {
   }
 
   clearMany(cells, updateUI, renderBoard, launchConfetti, updateBackground, resetHintTimer) {
-    playRandomTone();
     const base = cells.length;
     const bonus = (this.cascadeCount - 1) * 0.5;
     this.totalScore += base + bonus;
     this.levelScore += base + bonus;
     this.cascadeCount++;
     const awarded = this.checkShuffleAward();
+    if (!awarded) playRandomTone();
     if (awarded && updateUI) updateUI();
 
     const prevRows = this.boardRows;


### PR DESCRIPTION
## Summary
- use separate synths for random tones and jingles
- only play match tone if a shuffle wasn't earned

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844705e8dd8832fa585aead1b21ea40