### PR TITLE
Restore tile shake on invalid moves

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -81,6 +81,18 @@ function resetHint() {
   game.resetHintTimer(() => game.showHint(renderBoard));
 }
 
+function shakeTiles(cells) {
+  const tiles = document.querySelectorAll('.tile');
+  cells.forEach(([r, c]) => {
+    const el = tiles[r * game.boardCols + c];
+    if (!el) return;
+    el.classList.add('shake');
+    el.addEventListener('animationend', () => el.classList.remove('shake'), {
+      once: true,
+    });
+  });
+}
+
 function handleClick(r, c) {
   game.handleClick(
     r,
@@ -94,7 +106,8 @@ function handleClick(r, c) {
         game.launchConfetti.bind(game),
         updateBackground,
         resetHint
-      )
+      ),
+    shakeTiles
   );
 }
 


### PR DESCRIPTION
## Summary
- implement `shakeTiles` in `ui.js` to animate invalid moves
- pass new callback to `Game.handleClick`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68447322e128832f8abfec1f9ff710b0