### PR TITLE
Add deterministic tests

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -51,7 +51,8 @@ export function findRuns(board, length) {
 }
 
 export class Game {
-  constructor() {
+  constructor(options = {}) {
+    this.random = options.random || Math.random;
     this.level = 1;
     this.levelScore = 0;
     this.totalScore = 0;
@@ -73,7 +74,7 @@ export class Game {
   }
 
   getRandomTile() {
-    return tileTypes[Math.floor(Math.random() * tileTypes.length)];
+    return tileTypes[Math.floor(this.random() * tileTypes.length)];
   }
 
   generateBoard() {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "node test/findRuns.test.mjs"
+    "test": "sh -c 'for f in test/*.test.mjs; do node \"$f\"; done'"
   }
 }

--- a/test/findHint.test.mjs
+++ b/test/findHint.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'assert';
+import { Game } from '../js/game.js';
+
+function runTests() {
+  const game = new Game();
+  game.boardRows = 3;
+  game.boardCols = 3;
+  game.board = [
+    ['A','B','A'],
+    ['B','A','C'],
+    ['D','E','F'],
+  ];
+  const hint = game.findHint();
+  assert.deepStrictEqual(hint, { r1: 0, c1: 1, r2: 1, c2: 1 });
+  console.log('findHint tests passed');
+}
+
+runTests();

--- a/test/generateBoard.test.mjs
+++ b/test/generateBoard.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'assert';
+import { Game } from '../js/game.js';
+
+function* sequence() {
+  const values = [0, 1, 2, 3, 4, 5];
+  let i = 0;
+  while (true) {
+    yield values[i % values.length] / values.length;
+    i++;
+  }
+}
+
+function runTests() {
+  const seq = sequence();
+  const game = new Game({ random: () => seq.next().value });
+  // ensure board dimensions
+  assert.strictEqual(game.board.length, game.boardRows, 'row count');
+  assert.strictEqual(game.board[0].length, game.boardCols, 'col count');
+  // board should start without any matches
+  assert.strictEqual(game.findAllMatches().length, 0, 'no initial matches');
+  console.log('generateBoard tests passed');
+}
+
+runTests();

--- a/test/handleClick.test.mjs
+++ b/test/handleClick.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'assert';
+import { Game } from '../js/game.js';
+
+function createGameWithBoard(board) {
+  const game = new Game();
+  game.boardRows = board.length;
+  game.boardCols = board[0].length;
+  game.board = board.map(row => row.slice());
+  return game;
+}
+
+function runTests() {
+  let renderCalls = 0;
+  const renderBoard = () => { renderCalls++; };
+  const resetHint = () => {};
+
+  // swap leading to match
+  const matchBoard = [
+    ['A','A','B'],
+    ['B','B','C'],
+    ['D','E','F'],
+  ];
+  const game1 = createGameWithBoard(matchBoard);
+  let processed = 0;
+  const processMatches = () => { processed++; };
+  let shaken = null;
+  const shakeTiles = coords => { shaken = coords; };
+  const originalSetTimeout = global.setTimeout;
+  global.setTimeout = (fn) => { fn(); };
+
+  game1.handleClick(0,2, renderBoard, resetHint, processMatches, shakeTiles);
+  assert.ok(game1.selectedTile, 'tile selected');
+  game1.handleClick(1,2, renderBoard, resetHint, processMatches, shakeTiles);
+  assert.strictEqual(game1.selectedTile, null, 'selection cleared');
+  assert.strictEqual(game1.board[0][2], 'C');
+  assert.strictEqual(game1.board[1][2], 'B');
+  assert.strictEqual(processed, 1, 'processMatches called');
+  assert.strictEqual(shaken, null, 'no shake on valid move');
+
+  // invalid swap
+  const game2 = createGameWithBoard(matchBoard);
+  let processed2 = 0;
+  let shaken2 = null;
+  game2.handleClick(0,1, renderBoard, resetHint, () => processed2++, coords => shaken2 = coords);
+  game2.handleClick(0,2, renderBoard, resetHint, () => processed2++, coords => shaken2 = coords);
+  assert.strictEqual(game2.board[0][1], 'A');
+  assert.strictEqual(game2.board[0][2], 'B');
+  assert.strictEqual(processed2, 0, 'processMatches not called');
+  assert.deepStrictEqual(shaken2, [[0,1],[0,2]], 'shakeTiles called with swapped coords');
+
+  global.setTimeout = originalSetTimeout;
+  console.log('handleClick tests passed');
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- inject custom random source for deterministic board generation
- run all test files via npm test
- add tests for `generateBoard`, `findHint`, and `handleClick`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68447640a068832f88e3dbe1a1035fc0