### PR TITLE
Fix shake animation on invalid move

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -177,6 +177,7 @@ export class Game {
           [sr, sc],
           [r, c],
         ]);
+        return; // avoid clearing shake animation
       }
     } else {
       this.selectedTile = { r, c };


### PR DESCRIPTION
## Summary
- keep shake class on tiles by returning before the final render call

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844b753a368832f9b5a9f3b3b8b8b8d