### PR TITLE
Update fall distance calc

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -292,7 +292,7 @@ export class Game {
       }
       for (let r = 0; r < empty; r++) {
         this.board[r][c] = this.getRandomTile();
-        fallMap[`${r},${c}`] = r - (-1 - r);
+        fallMap[`${r},${c}`] = empty - r;
       }
     }
     renderBoard();

--- a/test/refillBoard.test.mjs
+++ b/test/refillBoard.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'assert';
+import { Game } from '../js/game.js';
+
+function* sequence() {
+  const values = [0, 1, 2, 3, 4, 5];
+  let i = 0;
+  while (true) {
+    yield values[i % values.length] / values.length;
+    i++;
+  }
+}
+
+function createGame(board) {
+  const seq = sequence();
+  const game = new Game({ random: () => seq.next().value });
+  game.boardRows = board.length;
+  game.boardCols = board[0].length;
+  game.board = board.map(row => row.slice());
+  return game;
+}
+
+function runTests() {
+  const board = [
+    ['A', null, 'B'],
+    [null, 'C', null],
+    ['D', null, 'E'],
+  ];
+  const game = createGame(board);
+
+  const originalDoc = global.document;
+  const originalRAF = global.requestAnimationFrame;
+  global.document = { querySelectorAll: () => [] };
+  global.requestAnimationFrame = fn => fn();
+
+  game.refillBoard(() => {}, () => {}, () => {});
+
+  game.board.forEach(row => row.forEach(cell => {
+    assert.notStrictEqual(cell, null, 'board should not contain null after refill');
+  }));
+
+  global.document = originalDoc;
+  global.requestAnimationFrame = originalRAF;
+  console.log('refillBoard tests passed');
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- fix calculation for new tile fall distance in `refillBoard`
- add a regression test for `refillBoard` ensuring no nulls remain

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844bb556268832f9924eec98ee6f65a