### PR TITLE
Add tests for refillBoard and shuffleBoard

### DIFF
--- a/test/refillBoard.test.mjs
+++ b/test/refillBoard.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'assert';
+import { Game } from '../js/game.js';
+
+function runTests() {
+  const game = new Game();
+  game.boardRows = 3;
+  game.boardCols = 3;
+  game.board = [
+    ['A', 'B', null],
+    ['C', null, null],
+    ['D', 'E', 'F'],
+  ];
+
+  global.document = { querySelectorAll: () => [] };
+  global.requestAnimationFrame = (fn) => fn();
+
+  const renderBoard = () => {};
+  let hintResets = 0;
+  const resetHintTimer = () => { hintResets++; };
+
+  game.refillBoard(() => {}, renderBoard, resetHintTimer);
+
+  assert.strictEqual(game.board.length, game.boardRows, 'row count');
+  assert.strictEqual(game.board[0].length, game.boardCols, 'col count');
+  for (let r = 0; r < game.boardRows; r++)
+    for (let c = 0; c < game.boardCols; c++)
+      assert.notStrictEqual(game.board[r][c], null, `null at ${r},${c}`);
+
+  assert.strictEqual(hintResets, 1, 'resetHintTimer called');
+  console.log('refillBoard tests passed');
+}
+
+runTests();

--- a/test/shuffleBoard.test.mjs
+++ b/test/shuffleBoard.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'assert';
+import { Game } from '../js/game.js';
+
+function runTests() {
+  const boardNoHint = [
+    ['A','B','C'],
+    ['A','B','C'],
+    ['D','E','F'],
+  ];
+  const boardWithHint = [
+    ['A','B','A'],
+    ['B','A','C'],
+    ['D','E','F'],
+  ];
+
+  const game = new Game();
+  game.boardRows = 3;
+  game.boardCols = 3;
+  game.board = boardNoHint.map(row => row.slice());
+
+  let generateCalls = 0;
+  game.generateBoard = () => {
+    generateCalls++;
+    return boardWithHint.map(row => row.slice());
+  };
+
+  const renderBoard = () => {};
+  const resetHint = () => {};
+  const updateBg = () => {};
+
+  let processed = 0;
+  game.processMatches = () => { processed++; };
+
+  const originalSetTimeout = global.setTimeout;
+  global.setTimeout = (fn) => { fn(); };
+
+  game.shuffleBoard(null, renderBoard, resetHint, updateBg);
+
+  global.setTimeout = originalSetTimeout;
+
+  assert.deepStrictEqual(game.board, boardWithHint, 'board regenerated');
+  assert.ok(game.findHint(), 'hint exists after shuffle');
+  assert.strictEqual(processed, 1, 'processMatches called');
+  assert.strictEqual(generateCalls, 1, 'generateBoard called once');
+
+  console.log('shuffleBoard tests passed');
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- ensure `refillBoard` fills the board with valid tiles
- add coverage for `shuffleBoard` regeneration and hint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844bb631ecc832face47ef0a67a5598