### PR TITLE
Add URL-based starting level

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -51,13 +51,24 @@ export function findRuns(board, length) {
 }
 
 export class Game {
+  static boardSizeForLevel(lv) {
+    let rows = 5;
+    let cols = 5;
+    for (let i = 2; i <= lv; i++) {
+      if (i % 5 === 0) cols = Math.min(cols + 1, 20);
+      if (i % 10 === 0) rows = Math.min(rows + 1, 15);
+    }
+    return { rows, cols };
+  }
+
   constructor(options = {}) {
     this.random = options.random || Math.random;
-    this.level = 1;
+    this.level = options.level || 1;
     this.levelScore = 0;
     this.totalScore = 0;
-    this.boardRows = 5;
-    this.boardCols = 5;
+    const size = Game.boardSizeForLevel(this.level);
+    this.boardRows = size.rows;
+    this.boardCols = size.cols;
     this.board = [];
     this.selectedTile = null;
     this.gameOver = false;
@@ -361,12 +372,13 @@ export class Game {
     }, 50);
   }
 
-  resetGame() {
-    this.level = 1;
+  resetGame(level = 1) {
+    this.level = level;
     this.levelScore = 0;
     this.totalScore = 0;
-    this.boardRows = 5;
-    this.boardCols = 5;
+    const size = Game.boardSizeForLevel(this.level);
+    this.boardRows = size.rows;
+    this.boardCols = size.cols;
     this.gameOver = false;
     this.cascadeCount = 1;
     this.shuffles = 0;

--- a/js/ui.js
+++ b/js/ui.js
@@ -7,7 +7,10 @@ import {
   DISPLAY_HIGH_SCORE_COUNT,
 } from './scores.js';
 
-const game = new Game();
+const params = new URLSearchParams(window.location.search);
+const lvlParam = Number(params.get('level'));
+const startLevel = Number.isFinite(lvlParam) && lvlParam > 0 ? Math.floor(lvlParam) : 1;
+const game = new Game({ level: startLevel });
 let dragStart = null;
 const boardEl = document.getElementById('game');
 
@@ -228,7 +231,7 @@ export async function startGame() {
 export function restartGame() {
   document.getElementById('gameover-overlay').classList.remove('visible');
   document.getElementById('shuffle-overlay').classList.remove('visible');
-  game.resetGame();
+  game.resetGame(startLevel);
   updateBackground();
   renderBoard();
   resetHint();
@@ -262,7 +265,7 @@ boardEl.addEventListener('pointerdown', onBoardPointerDown);
 boardEl.addEventListener('pointerup', onBoardPointerUp);
 
 // Initial setup
-game.resetGame();
+game.resetGame(startLevel);
 renderBoard();
 resetHint();
 setTimeout(


### PR DESCRIPTION
## Summary
- allow passing a starting level in the URL for easier testing
- compute board size based on the provided level

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845ce27b4f8832f8827b0f960c94adc