### PR TITLE
Add lock tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.0] - 2025-06-09
+### Added
+- Locks appear from level 30 with a small chance after matches. Lock tiles block matches and are only cleared by row/column or board clears.
+
 ## [1.0.0] - 2025-06-08
 ### Added
 - High score tracking with display of the top results.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Completely vibe-coded to test AI capabilities using `ChatGPT o4-mini-high` (init
 - **High Scores**: Submit your name after game over to save your score and the level reached. View the top results via the trophy button.
 - **Random Tones**: Each match plays a random note using Tone.js.
 - **Shuffles**: Earn a shuffle every 100 points to continue when no moves remain.
+- **Lock Tiles from Level 30**: After matches, new tiles have a small chance to be 🔒 locks. Locks block matches until cleared by a row/column or board clear.
 
 ## Getting Started
 

--- a/js/game.js
+++ b/js/game.js
@@ -1,6 +1,7 @@
 import { playRandomTone, playJingle } from './audio.js';
 
 export const tileTypes = ["💎", "🔶", "🔷", "🔴", "🟢", "🟣"];
+export const lockTile = "🔒";
 
 export function findRuns(board, length) {
   const rows = board.length;
@@ -13,7 +14,8 @@ export function findRuns(board, length) {
       if (
         c < cols &&
         board[r][c] === board[r][c - 1] &&
-        board[r][c] !== null
+        board[r][c] !== null &&
+        board[r][c] !== lockTile
       ) {
         run++;
       } else {
@@ -33,7 +35,8 @@ export function findRuns(board, length) {
       if (
         r < rows &&
         board[r][c] === board[r - 1][c] &&
-        board[r][c] !== null
+        board[r][c] !== null &&
+        board[r][c] !== lockTile
       ) {
         run++;
       } else {
@@ -88,6 +91,11 @@ export class Game {
     return tileTypes[Math.floor(this.random() * tileTypes.length)];
   }
 
+  getAddedTile() {
+    if (this.level >= 30 && this.random() < 0.1) return lockTile;
+    return this.getRandomTile();
+  }
+
   generateBoard() {
     const b = [];
     for (let r = 0; r < this.boardRows; r++) {
@@ -104,6 +112,7 @@ export class Game {
   }
 
   isMatch(b, r, c, t) {
+    if (t === lockTile) return false;
     return (
       (c >= 2 && b[r][c - 1] === t && b[r][c - 2] === t) ||
       (r >= 2 && b[r - 1][c] === t && b[r - 2][c] === t)
@@ -128,7 +137,8 @@ export class Game {
         if (
           this.board[r][c] &&
           this.board[r][c] === this.board[r][c + 1] &&
-          this.board[r][c] === this.board[r][c + 2]
+          this.board[r][c] === this.board[r][c + 2] &&
+          this.board[r][c] !== lockTile
         )
           m.push([r, c], [r, c + 1], [r, c + 2]);
     for (let c = 0; c < this.boardCols; c++)
@@ -136,7 +146,8 @@ export class Game {
         if (
           this.board[r][c] &&
           this.board[r][c] === this.board[r + 1][c] &&
-          this.board[r][c] === this.board[r + 2][c]
+          this.board[r][c] === this.board[r + 2][c] &&
+          this.board[r][c] !== lockTile
         )
           m.push([r, c], [r + 1, c], [r + 2, c]);
     return Array.from(new Set(m.map(JSON.stringify)), JSON.parse);
@@ -271,10 +282,10 @@ export class Game {
     if (this.boardCols > prevCols || this.boardRows > prevRows) {
       for (let r = 0; r < prevRows; r++)
         for (let c = prevCols; c < this.boardCols; c++)
-          this.board[r][c] = this.getRandomTile();
+          this.board[r][c] = this.getAddedTile();
       for (let r = prevRows; r < this.boardRows; r++) {
         this.board[r] = [];
-        for (let c = 0; c < this.boardCols; c++) this.board[r][c] = this.getRandomTile();
+        for (let c = 0; c < this.boardCols; c++) this.board[r][c] = this.getAddedTile();
       }
     }
 
@@ -302,7 +313,7 @@ export class Game {
         }
       }
       for (let r = 0; r < empty; r++) {
-        this.board[r][c] = this.getRandomTile();
+        this.board[r][c] = this.getAddedTile();
         fallMap[`${r},${c}`] = empty - r;
       }
     }

--- a/test/lockTile.test.mjs
+++ b/test/lockTile.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'assert';
+import { Game, lockTile, findRuns } from '../js/game.js';
+
+function* sequence() {
+  const values = [0, 1, 2, 3, 4, 5];
+  let i = 0;
+  while (true) {
+    yield values[i % values.length] / values.length;
+    i++;
+  }
+}
+
+function runTests() {
+  const seq = sequence();
+  // first call returns 0.05 for lock generation
+  const rand = () => (seq.next().value);
+  const game = new Game({ level: 30, random: rand });
+  game.random = () => 0.05; // force lock chance
+  assert.strictEqual(game.getAddedTile(), lockTile, 'lock tile generated');
+
+  const board = [[lockTile, lockTile, lockTile]];
+  assert.deepStrictEqual(findRuns(board, 3), [], 'no runs with locks');
+  game.boardRows = 1;
+  game.boardCols = 3;
+  game.board = board.map(row => row.slice());
+  assert.strictEqual(game.findAllMatches().length, 0, 'findAllMatches ignores locks');
+
+  console.log('lockTile tests passed');
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- introduce 🔒 lock tile that has a chance to appear on refills from level 30
- prevent lock tiles from forming matches
- document lock tile mechanic and update changelog
- test lock tile behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845d103c328832f8fd42fed1f7167b5