### PR TITLE
Limit lock tile generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.0] - 2025-06-08 14:33 ET
+### Added
+- Lock tiles are limited to 7% of the board.
+
 ## [1.2.0] - 2025-06-08
 ### Added
 - Lock tiles can no longer be selected or swapped by the player.

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     <div id="progress"><div class="bar"></div></div>
     <div id="game"></div>
     <div id="version-info">
-      Vibey Crush v1.2.0 - Last updated: 2025-06-08 14:00 UTC -
+      Vibey Crush v1.3.0 - Last updated: 2025-06-08 14:33 ET -
       <a href="https://github.com/mDisna/Vibey-Crush/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Change Log</a>
     </div>
 

--- a/js/game.js
+++ b/js/game.js
@@ -92,7 +92,11 @@ export class Game {
   }
 
   getAddedTile() {
-    if (this.level >= 30 && this.random() < 0.1) return lockTile;
+    if (this.level >= 30 && this.random() < 0.1) {
+      const total = this.boardRows * this.boardCols;
+      const locks = this.board.flat().filter(t => t === lockTile).length;
+      if (locks / total < 0.07) return lockTile;
+    }
     return this.getRandomTile();
   }
 

--- a/test/lockTile.test.mjs
+++ b/test/lockTile.test.mjs
@@ -18,12 +18,26 @@ function runTests() {
   game.random = () => 0.05; // force lock chance
   assert.strictEqual(game.getAddedTile(), lockTile, 'lock tile generated');
 
+  // limit test: should not add more locks when 7% or more already present
+  game.boardRows = 1;
+  game.boardCols = 10;
+  game.board = [
+    [lockTile, 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I']
+  ];
+  assert.notStrictEqual(game.getAddedTile(), lockTile, 'lock limit enforced');
+
   const board = [[lockTile, lockTile, lockTile]];
   assert.deepStrictEqual(findRuns(board, 3), [], 'no runs with locks');
   game.boardRows = 1;
   game.boardCols = 3;
   game.board = board.map(row => row.slice());
   assert.strictEqual(game.findAllMatches().length, 0, 'findAllMatches ignores locks');
+
+  // allow lock when under limit
+  game.boardRows = 1;
+  game.boardCols = 10;
+  game.board = [['A','B','C','D','E','F','G','H','I','J']];
+  assert.strictEqual(game.getAddedTile(), lockTile, 'lock allowed under limit');
 
   console.log('lockTile tests passed');
 }


### PR DESCRIPTION
## Summary
- cap lock tiles at 7% of the board in `getAddedTile`
- document limit in changelog and bump version
- display updated version info in the game UI
- test lock tile cap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845d7291864832f9b75476ce8c939af