### PR TITLE
Document lock tiles in help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.0] - 2025-06-08 14:44 ET
+### Added
+- Help screen now explains how lock tiles work.
+
 ## [1.3.0] - 2025-06-08 14:33 ET
 ### Added
 - Lock tiles are limited to 7% of the board.

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     <div id="progress"><div class="bar"></div></div>
     <div id="game"></div>
     <div id="version-info">
-      Vibey Crush v1.3.0 - Last updated: 2025-06-08 14:33 ET -
+      Vibey Crush v1.4.0 - Last updated: 2025-06-08 14:44 ET -
       <a href="https://github.com/mDisna/Vibey-Crush/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Change Log</a>
     </div>
 
@@ -98,6 +98,11 @@
           <li><span class="example">🟣🟣🟣🟣🟣</span> Matching 5 clears the entire board.</li>
           <li>Earn a <strong>Shuffle</strong> every 100 points.</li>
           <li>The board grows larger every 5 levels.</li>
+          <li>
+            <span class="example">🔒</span> Lock tiles appear from level 30.
+            They block swaps and matches and can only be cleared by row,
+            column, or board clears.
+          </li>
         </ul>
         <p>
           This game was Vibe-Coded using ChatGPT o4-mini-high and OpenAI Codex by


### PR DESCRIPTION
## Summary
- document lock tile behavior in the help overlay
- bump game version and changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845d9b56050832f9b330ef9e56debbe